### PR TITLE
modified client.Do signature.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -35,10 +35,7 @@ func New(w wallet.Wallet, s tokenstore.Store) *Client {
 
 // Do makes an HTTP request and handles L402 payment challenges.
 // It automatically pays the invoice and retries the request with the L402 token if a 402 Payment Required response is received.
-func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
-	// Ensure the request context is set
-	req = req.WithContext(ctx)
-
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	// Try to retrieve and use L402 token if available
 	l402Token, ok := c.store.Get(req.URL)
 	if ok {
@@ -52,7 +49,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, err
 
 	if response.StatusCode == http.StatusPaymentRequired {
 		authHeader := response.Header.Get("WWW-Authenticate")
-		return c.handlePaymentChallenge(ctx, authHeader, req.URL.String(), req.Method)
+		return c.handlePaymentChallenge(req.Context(), authHeader, req.URL.String(), req.Method)
 	}
 
 	return response, nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -92,13 +92,12 @@ func TestMakeRequest(t *testing.T) {
 			client := New(mockWallet, tokenstore.NewNoopStore())
 
 			// Create the *http.Request object with the test server's URL
-			req, err := http.NewRequest("GET", server.URL, nil)
+			req, err := http.NewRequestWithContext(context.Background(), "GET", server.URL, nil)
 			if err != nil {
 				t.Fatalf("Failed to create request: %v", err)
 			}
 
-			// Now use the modified MakeRequest function which takes *http.Request
-			resp, err := client.Do(context.Background(), req)
+			resp, err := client.Do(req)
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("MakeRequest() error = %v, wantError %v", err, tt.wantError)

--- a/e2e/alby_client_test.go
+++ b/e2e/alby_client_test.go
@@ -38,8 +38,7 @@ func TestAlbyClientE2E(t *testing.T) {
 		t.Fatalf("Failed to create request: %v", err)
 	}
 
-	// Use the modified MakeRequest function which takes *http.Request
-	response, err := client.Do(ctx, req)
+	response, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("Failed to make request: %v", err)
 	}

--- a/e2e/lnd_client_test.go
+++ b/e2e/lnd_client_test.go
@@ -36,8 +36,7 @@ func TestLndClientE2E(t *testing.T) {
 	req, err := http.NewRequestWithContext(ctx, "GET", "http://aperture:8700/randomnumber", nil)
 	require.NoError(t, err)
 
-	// Use the modified MakeRequest function which takes *http.Request
-	response, err := client.Do(ctx, req)
+	response, err := client.Do(req)
 	require.NoError(t, err)
 	defer response.Body.Close()
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sulusolutions/gol402
 
-go 1.21.3
+go 1.21
 
 require github.com/lightninglabs/lndclient v1.0.0
 


### PR DESCRIPTION
Removed ctx argument to conform to the http.Client.Do() function signature (easier substitutions).