### PR TITLE
Fixes quick start code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ func main() {
 		t.Fatalf("Failed to create request: %v", err)
 	}
 
-	response, err := client.Do(req)
+	response, err := l402Client.Do(req)
 	if err != nil {
 		t.Fatalf("Failed to make request: %v", err)
 	}


### PR DESCRIPTION
**Minor fix:** `l402Client` should be used instead of `client` to perform operations after new client is setup.